### PR TITLE
feat: disease content type

### DIFF
--- a/src/api/disease/content-types/disease/schema.json
+++ b/src/api/disease/content-types/disease/schema.json
@@ -1,0 +1,61 @@
+{
+  "kind": "collectionType",
+  "collectionName": "diseases",
+  "info": {
+    "singularName": "disease",
+    "pluralName": "diseases",
+    "displayName": "Disease"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "topic": {
+      "type": "string",
+      "required": true,
+      "unique": false
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "query": {
+      "type": "json",
+      "required": true
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "contacts": {
+      "type": "component",
+      "component": "shared.link-item",
+      "repeatable": true
+    },
+    "externalLinks": {
+      "type": "component",
+      "component": "shared.link-item",
+      "repeatable": true
+    }
+  }
+}

--- a/src/api/disease/controllers/disease.js
+++ b/src/api/disease/controllers/disease.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * disease controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::disease.disease');

--- a/src/api/disease/controllers/disease.js
+++ b/src/api/disease/controllers/disease.js
@@ -1,9 +1,124 @@
-'use strict';
+"use strict";
+
+const { createCoreController } = require("@strapi/strapi").factories;
 
 /**
- * disease controller
+ * Custom disease controller
+ *
+ * This controller extends Strapi's default controller to ensure that all
+ * disease API responses include properly populated nested data (images,
+ * categories in link items) and handle both published and draft content.
  */
+module.exports = createCoreController("api::disease.disease", ({ strapi }) => ({
+  /**
+   * Helper method: Get population configuration
+   *
+   * Defines what related data should be fetched when querying diseases.
+   *
+   * @returns Population configuration object
+   */
+  getPopulateConfig() {
+    return {
+      // Populate the main disease image (media field)
+      image: true,
 
-const { createCoreController } = require('@strapi/strapi').factories;
+      // For the 'contacts' component array, populate nested fields
+      contacts: {
+        populate: {
+          image: true,
+          categories: true,
+        },
+      },
 
-module.exports = createCoreController('api::disease.disease');
+      // For the 'externalLinks' component array, populate nested fields
+      externalLinks: {
+        populate: {
+          image: true,
+          categories: true,
+        },
+      },
+    };
+  },
+
+  /**
+   * Helper method: Build query options
+   *
+   * Constructs the complete query options object that will be passed to
+   * Strapi's entity service.
+   *
+   * @param {Object} ctx - Context object containing request data
+   * @param {Object} additionalOptions - Any extra options to merge in
+   * @returns {Object} Complete query options for entityService
+   */
+  async buildQueryOptions(ctx, additionalOptions = {}) {
+    // Sanitize the incoming query to remove dangerous parameters
+    const sanitizedQuery = await this.sanitizeQuery(ctx);
+
+    // Get population configuration
+    const populateConfig = this.getPopulateConfig();
+
+    // Build the base options object
+    const options = {
+      ...sanitizedQuery,
+      populate: populateConfig,
+      ...additionalOptions,
+    };
+
+    // Handle draft/published content state
+    if (ctx.query.publicationState === "preview") {
+      options.publicationState = "preview"; // Show both published and draft content
+    }
+    // If no publicationState is specified, Strapi defaults to published-only
+    return options;
+  },
+
+  /**
+   * Find Method - Get multiple diseases
+   *
+   * @param {Object} ctx - Context object
+   * @returns {Object} Transformed API response with populated data
+   */
+  async find(ctx) {
+    // Build query options
+    const options = await this.buildQueryOptions(ctx);
+
+    // Fetch multiple disease records using Strapi's entity service
+    const entities = await strapi.entityService.findMany(
+      "api::disease.disease",
+      options,
+    );
+
+    // Sanitize the output to remove any sensitive data
+    const sanitizedResults = await this.sanitizeOutput(entities, ctx);
+
+    // Transform the results into Strapi's standard API response format
+    return this.transformResponse(sanitizedResults);
+  },
+
+  /**
+   * FindOne Method - Get single disease
+   *
+   * @param {Object} ctx - Context object
+   * @returns {Object} Transformed API response with populated data
+   */
+  async findOne(ctx) {
+    // Extract the disease ID from the URL parameters
+    const { id } = ctx.params;
+
+    // Build query options
+    const options = await this.buildQueryOptions(ctx);
+
+    // Fetch a single disease record by ID using Strapi's entity service
+    const entity = await strapi.entityService.findOne(
+      "api::disease.disease",
+      id,
+      options,
+    );
+
+    // Sanitize the output to remove any sensitive data
+    const sanitizedResult = await this.sanitizeOutput(entity, ctx);
+
+    // Transform the result into Strapi's standard API response format
+    return this.transformResponse(sanitizedResult);
+  },
+}));

--- a/src/api/disease/routes/disease.js
+++ b/src/api/disease/routes/disease.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * disease router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::disease.disease');

--- a/src/api/disease/services/disease.js
+++ b/src/api/disease/services/disease.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * disease service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::disease.disease');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -474,6 +474,45 @@ export interface ApiDisclaimerPageDisclaimerPage
   };
 }
 
+export interface ApiDiseaseDisease extends Struct.CollectionTypeSchema {
+  collectionName: 'diseases';
+  info: {
+    displayName: 'Disease';
+    pluralName: 'diseases';
+    singularName: 'disease';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    contacts: Schema.Attribute.Component<'shared.link-item', true>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.RichText;
+    externalLinks: Schema.Attribute.Component<'shared.link-item', true>;
+    image: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::disease.disease'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    query: Schema.Attribute.JSON & Schema.Attribute.Required;
+    slug: Schema.Attribute.UID<'title'> & Schema.Attribute.Required;
+    subtitle: Schema.Attribute.String;
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    topic: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiDocDoc extends Struct.CollectionTypeSchema {
   collectionName: 'docs';
   info: {
@@ -1278,6 +1317,7 @@ declare module '@strapi/strapi' {
       'api::about-page.about-page': ApiAboutPageAboutPage;
       'api::category.category': ApiCategoryCategory;
       'api::disclaimer-page.disclaimer-page': ApiDisclaimerPageDisclaimerPage;
+      'api::disease.disease': ApiDiseaseDisease;
       'api::doc.doc': ApiDocDoc;
       'api::event.event': ApiEventEvent;
       'api::feature.feature': ApiFeatureFeature;


### PR DESCRIPTION
# Summary

This PR creates the disease content type and auxiliary files to enable the NDE portal to display content from Strapi.

Related issue: https://github.com/NIAID-Data-Ecosystem/nde-portal/issues/318